### PR TITLE
Corrects FlowStyle naming

### DIFF
--- a/src/main/scala/io/circe/yaml/Printer.scala
+++ b/src/main/scala/io/circe/yaml/Printer.scala
@@ -17,8 +17,8 @@ final case class Printer(
   splitLines: Boolean = true,
   indicatorIndent: Int = 0,
   tags: Map[String, String] = Map.empty,
-  sequenceStyle: FlowStyle = FlowStyle.Flow,
-  mappingStyle: FlowStyle = FlowStyle.Flow,
+  sequenceStyle: FlowStyle = FlowStyle.Block,
+  mappingStyle: FlowStyle = FlowStyle.Block,
   stringStyle: StringStyle = StringStyle.Plain,
   lineBreak: LineBreak = LineBreak.Unix,
   explicitStart: Boolean = false,
@@ -87,7 +87,7 @@ final case class Printer(
         obj.toMap
       new MappingNode(Tag.MAP, map.map {
         case (k, v) => new NodeTuple(scalarNode(Tag.STR, k), jsonToYaml(v))
-      }.toList.asJava, mappingStyle == FlowStyle.Block)
+      }.toList.asJava, mappingStyle == FlowStyle.Flow)
     }
 
     json.fold(
@@ -103,7 +103,7 @@ final case class Printer(
       str =>
         stringNode(str),
       arr =>
-        new SequenceNode(Tag.SEQ, arr.map(jsonToYaml).asJava, sequenceStyle == FlowStyle.Block),
+        new SequenceNode(Tag.SEQ, arr.map(jsonToYaml).asJava, sequenceStyle == FlowStyle.Flow),
       obj =>
         convertObject(obj)
     )

--- a/src/test/scala/io/circe/yaml/PrinterTests.scala
+++ b/src/test/scala/io/circe/yaml/PrinterTests.scala
@@ -9,8 +9,8 @@ class PrinterTests extends FreeSpec with Matchers {
   "Flow style" - {
     val json = Json.obj("foo" -> Json.arr((0 until 3).map(_.toString).map(Json.fromString): _*))
 
-    "Flow" in {
-      val printer = Printer.spaces2.copy(sequenceStyle = FlowStyle.Flow, mappingStyle = FlowStyle.Flow)
+    "Block" in {
+      val printer = Printer.spaces2.copy(sequenceStyle = FlowStyle.Block, mappingStyle = FlowStyle.Block)
       printer.pretty(json) shouldEqual
         """foo:
           |- '0'
@@ -19,8 +19,8 @@ class PrinterTests extends FreeSpec with Matchers {
           |""".stripMargin
     }
 
-    "Block" in {
-      val printer = Printer.spaces2.copy(sequenceStyle = FlowStyle.Block, mappingStyle = FlowStyle.Block)
+    "Flow" in {
+      val printer = Printer.spaces2.copy(sequenceStyle = FlowStyle.Flow, mappingStyle = FlowStyle.Flow)
       printer.pretty(json) shouldEqual
         """{foo: ['0', '1', '2']}
           |""".stripMargin


### PR DESCRIPTION
See http://yaml.org/spec/current.html#id2502325

Flow is inline {a: 1, b: 2}, while block has every key-value pair on its own line.

I changed the default parameters so that the `.spaces2/4` default printers have their effective behavior unchanged.