### PR TITLE
Added option to preserve key order in mappings.

### DIFF
--- a/src/test/scala/io/circe/yaml/PrinterTests.scala
+++ b/src/test/scala/io/circe/yaml/PrinterTests.scala
@@ -27,6 +27,20 @@ class PrinterTests extends FreeSpec with Matchers {
     }
   }
 
+  "Preserves order" - {
+    val kvPairs = Seq("d" -> 4, "a" -> 1, "b" -> 2, "c" -> 3)
+    val json = Json.obj(kvPairs.map { case (k, v) => (k -> Json.fromInt(v)) }: _*)
+    "true" in {
+      val printer = Printer(preserveOrder = true)
+      printer.pretty(json) shouldEqual
+      """d: 4
+        |a: 1
+        |b: 2
+        |c: 3
+        |""".stripMargin
+    }
+  }
+
   "Scalar style" - {
     val foos = Seq.fill(40)("foo")
     val foosSplit = Seq(foos.take(19), foos.slice(19, 39), foos.slice(39, 40)).map(_.mkString(" "))


### PR DESCRIPTION
The implementation follows the standard JSON printer.

There is a bug in the FlowStyle convention, see #22 . This PR follows the convention before #22, so the line

> new MappingNode(Tag.MAP, childNodes.toList.asJava, mappingStyle == FlowStyle.Block)

of this PR should be corrected after #22 to

>  new MappingNode(Tag.MAP, childNodes.toList.asJava, mappingStyle == FlowStyle.Flow)