### PR TITLE
Update SnakeYAML and other versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.10.6
-  - 2.11.8
+  - 2.11.11
 
 jdk:
   - oraclejdk7
@@ -10,7 +10,7 @@ jdk:
 
 matrix:
   include:
-  - scala: 2.12.1
+  - scala: 2.12.2
     jdk: oraclejdk8
 
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
-
 organization in ThisBuild := "io.circe"
 
 val compilerOptions = Seq(
@@ -20,12 +18,13 @@ val Versions = new {
   val discipline = "0.7.3"
   val scalaCheck = "1.13.5"
   val scalaTest = "3.0.3"
-  val snakeYaml = "1.17"
+  val snakeYaml = "1.18"
 }
 
 val docMappingsApiDir = settingKey[String]("Subdirectory in site target directory for API docs")
 
 val root = project.in(file("."))
+  .enablePlugins(GhpagesPlugin)
   .settings(
     name := "circe-yaml",
     description := "Library for converting between SnakeYAML's AST and circe's AST",
@@ -51,7 +50,7 @@ val root = project.in(file("."))
       "org.scalatest" %% "scalatest" % Versions.scalaTest % "test"
     )
   )
-  .settings(publishSettings ++ docSettings ++ ghpages.settings)
+  .settings(publishSettings ++ docSettings)
 
 lazy val docSettings = Seq(
   autoAPIMappings := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,13 +6,13 @@ resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
-addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.0.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/src/test/scala/io/circe/yaml/PrinterTests.scala
+++ b/src/test/scala/io/circe/yaml/PrinterTests.scala
@@ -49,7 +49,7 @@ class PrinterTests extends FreeSpec with Matchers {
     val json = Json.obj("foo" -> Json.fromString(foosPlain))
 
     "Plain" in {
-      val printer = Printer.spaces2.copy(stringStyle = StringStyle.Plain)
+      val printer = Printer.spaces2.copy(splitLines = false, stringStyle = StringStyle.Plain)
       printer.pretty(json) shouldEqual
         s"""foo: $foosPlain
            |""".stripMargin

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.0-SNAPSHOT"
+version in ThisBuild := "0.6.0-SNAPSHOT"


### PR DESCRIPTION
I'm about to publish an 0.6.0 release for circe 0.8.0 and went ahead and updated to the new SnakeYAML version (1.18).

There's one change to the tests that's needed because of [a change in SnakeYAML](https://bitbucket.org/asomov/snakeyaml/issues/355/dumping-long-string-values-are-not-split) (long string values are now split across lines if `splitLines` is true).

/cc @n4to4 @denisrosset @jeremyrsmith @jeffmay @jonas 