### PR TITLE
bump circe dependency to 0.9.0-M1 and fix deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val compilerOptions = Seq(
 )
 
 val Versions = new {
-  val circe = "0.8.0"
+  val circe = "0.9.0-M1"
   val discipline = "0.7.3"
   val scalaCheck = "1.13.5"
   val scalaTest = "3.0.3"

--- a/src/main/scala/io/circe/yaml/Printer.scala
+++ b/src/main/scala/io/circe/yaml/Printer.scala
@@ -88,7 +88,7 @@ final case class Printer(
   private def jsonToYaml(json: Json): Node = {
 
     def convertObject(obj: JsonObject) = {
-      val fields = if (preserveOrder) obj.fields else obj.fieldSet
+      val fields = if (preserveOrder) obj.keys else obj.keys.toSet
       val m = obj.toMap
       val childNodes = fields.flatMap { key =>
         val value = m(key)


### PR DESCRIPTION
We're using cats 1.0.0-MF and this is the last holdout.  

Would you consider releasing a version based on a milestone?