### PR TITLE
Parse integers using SnakeYAML's parser

### DIFF
--- a/src/main/scala/io/circe/yaml/parser/package.scala
+++ b/src/main/scala/io/circe/yaml/parser/package.scala
@@ -63,7 +63,6 @@ package object parser {
             JsonDecimal(bigint.toString)
           case other => throw new NumberFormatException(s"Unexpected number type: ${other.getClass}")
         })
-      
       case Tag.INT | Tag.FLOAT => JsonNumber.fromString(node.getValue).map(Json.fromJsonNumber).getOrElse {
         throw new NumberFormatException(s"Invalid numeric string ${node.getValue}")
       }

--- a/src/main/scala/io/circe/yaml/parser/package.scala
+++ b/src/main/scala/io/circe/yaml/parser/package.scala
@@ -63,6 +63,7 @@ package object parser {
             JsonDecimal(bigint.toString)
           case other => throw new NumberFormatException(s"Unexpected number type: ${other.getClass}")
         })
+      
       case Tag.INT | Tag.FLOAT => JsonNumber.fromString(node.getValue).map(Json.fromJsonNumber).getOrElse {
         throw new NumberFormatException(s"Invalid numeric string ${node.getValue}")
       }

--- a/src/test/scala/io/circe/yaml/ParserTests.scala
+++ b/src/test/scala/io/circe/yaml/ParserTests.scala
@@ -1,6 +1,7 @@
 package io.circe.yaml
 
 import org.scalatest.{FlatSpec, Matchers}
+import io.circe.syntax._
 
 class ParserTests extends FlatSpec with Matchers {
   // the laws should do a pretty good job of surfacing errors; these are mainly to ensure test coverage
@@ -30,4 +31,15 @@ class ParserTests extends FlatSpec with Matchers {
     ).isRight)
   }
 
+  it should "parse hexadecimal" in {
+    assert(parser.parse(
+      """[0xFF, 0xff, 0xab_cd]"""
+    ).contains(Seq(0xFF, 0xff, 0xabcd).asJson))
+  }
+
+  it should "parse decimal with underscore breaks" in {
+    assert(parser.parse(
+      """foo: 1_000_000"""
+    ).contains(Map("foo" -> 1000000).asJson))
+  }
 }


### PR DESCRIPTION
Fixes #41

The round-trip test is still occasionally choking on inputs like `-0` and
`0e12356`, which I'm not quite sure how to fix yet, but I thought I'd get this
PR up in case it's helpful.