### PR TITLE
Use SnakeYAML's safe constructor for Bool parsing

### DIFF
--- a/src/test/scala/io/circe/yaml/ParserTests.scala
+++ b/src/test/scala/io/circe/yaml/ParserTests.scala
@@ -24,4 +24,10 @@ class ParserTests extends FlatSpec with Matchers {
     ).isLeft)
   }
 
+  it should "parse yes as true" in {
+    assert(parser.parse(
+      """foo: yes"""
+    ).isRight)
+  }
+
 }


### PR DESCRIPTION
In YAML `yes`, `no`, `on`, and `off` are also Boolean values. SnakeYAML's [SafeConstructor](https://bitbucket.org/asomov/snakeyaml/src/2d01fd0db006a19ac07c73425fcf36ab75392428/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java?at=default&fileviewer=file-view-default#SafeConstructor.java-201:209) provides the facility to perform the conversion to `java.lang.Boolean`.

