### PR TITLE
Use integer number format when using Int tag

### DIFF
--- a/src/main/scala/io/circe/yaml/Printer.scala
+++ b/src/main/scala/io/circe/yaml/Printer.scala
@@ -95,7 +95,7 @@ final case class Printer(
         scalarNode(Tag.BOOL, bool.toString),
       number => {
         if (number.toLong.nonEmpty)
-          scalarNode(Tag.INT, number.toString)
+          scalarNode(Tag.INT, number.toLong.get.toString)
         else
           scalarNode(Tag.FLOAT, number.toString)
       },


### PR DESCRIPTION
This PR fixes an issue where numbers which have integral values are output in fractional format, but with the `!!int` tag (originaly reported in #68)

Code to reproduce the issue:

```
import io.circe._
import io.circe.syntax._
import io.circe.generic.auto._

object Main extends App {
  case class Data(x: Double, y: Double)

  val foo = Seq(
    Data(0.0000001, 100000000),
    Data(0.1234567891234569, 1000)
  )

  val json = foo.asJson

  val printer = yaml.Printer.spaces2
  val yamlString = printer.pretty(json)

  println(yamlString)
}
```

The output before the fix is:

```
- x: 1.0E-7
  y: !!int '1.0E8'
- x: 0.1234567891234569
  y: !!int '1.0'
```

After the fix the output is much more natural:

```
- x: 1.0E-7
  y: 100000000
- x: 0.1234567891234569
  y: 1
```
