### PR TITLE
Drop discipline-scalatest dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ val root = project.in(file("."))
       "org.yaml" % "snakeyaml" % Versions.snakeYaml,
       "io.circe" %% "circe-testing" % Versions.circe % Test,
       "org.typelevel" %% "discipline-core" % Versions.discipline % Test,
-      "org.typelevel" %% "discipline-scalatest" % Versions.discipline % Test,
       "org.scalacheck" %% "scalacheck" % Versions.scalaCheck % Test,
       "org.scalatest" %% "scalatest" % Versions.scalaTest % Test,
       "org.scalatestplus" %% "scalatestplus-scalacheck" % Versions.scalaTestPlus % Test

--- a/src/test/scala/io/circe/yaml/SnakeYamlSymmetricSerializationTests.scala
+++ b/src/test/scala/io/circe/yaml/SnakeYamlSymmetricSerializationTests.scala
@@ -4,10 +4,18 @@ import io.circe.Json
 import io.circe.Json.eqJson
 import io.circe.testing.instances._
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.Laws
 
-class SnakeYamlSymmetricSerializationTests extends AnyFunSuite with Discipline with SymmetricSerializationTests {
+class SnakeYamlSymmetricSerializationTests extends AnyFunSuite with Checkers with SymmetricSerializationTests {
   override val laws: SymmetricSerializationLaws = SymmetricSerializationLaws()
+
+  def checkAll(name: String, ruleSet: Laws#RuleSet): Unit = {
+    for ((id, prop) <- ruleSet.all.properties)
+      test(name + "." + id) {
+        check(prop)
+      }
+  }
 
   checkAll("snake.printer", symmetricPrinter[Json](printer.print, parser.parse))
 }


### PR DESCRIPTION
Given that the future of this dependency is kind of up in the air and it can be replaced by a few lines of code, I think we should scrap it.