### PR TITLE
#68: properly detect if a number if a float or int

### DIFF
--- a/src/main/scala/io/circe/yaml/Printer.scala
+++ b/src/main/scala/io/circe/yaml/Printer.scala
@@ -93,12 +93,8 @@ final case class Printer(
       scalarNode(Tag.NULL, "null"),
       bool =>
         scalarNode(Tag.BOOL, bool.toString),
-      number => {
-        if (number.toLong.nonEmpty)
-          scalarNode(Tag.INT, number.toString)
-        else
-          scalarNode(Tag.FLOAT, number.toString)
-      },
+      number =>
+        scalarNode(numberTag(number), number.toString),
       str =>
         stringNode(str),
       arr =>
@@ -158,9 +154,12 @@ object Printer {
   private def yamlTag(json: Json) = json.fold(
     Tag.NULL,
     _ => Tag.BOOL,
-    number => if (number.toLong.nonEmpty) Tag.INT else Tag.FLOAT,
+    number => numberTag(number),
     _ => Tag.STR,
     _ => Tag.SEQ,
     _ => Tag.MAP
   )
+
+  private def numberTag(number: JsonNumber): Tag =
+    if (number.toString.contains(".")) Tag.FLOAT else Tag.INT
 }

--- a/src/test/scala/io/circe/yaml/PrinterTests.scala
+++ b/src/test/scala/io/circe/yaml/PrinterTests.scala
@@ -1,6 +1,6 @@
 package io.circe.yaml
 
-import io.circe.Json
+import io.circe.{Json, JsonNumber}
 import io.circe.yaml.Printer.{FlowStyle, LineBreak, StringStyle, YamlVersion}
 import org.scalatest.Matchers
 import org.scalatest.freespec.AnyFreeSpec
@@ -101,6 +101,11 @@ class PrinterTests extends AnyFreeSpec with Matchers {
   "Root float" in {
     val json = Json.fromDoubleOrNull(22.22)
     Printer.spaces2.pretty(json) shouldEqual "22.22\n"
+  }
+
+  "Root float without decimal part" in {
+    val json = Json.fromDoubleOrNull(22.0)
+    Printer.spaces2.pretty(json) shouldEqual "22.0\n"
   }
 
   "Version" in {


### PR DESCRIPTION
Floating-point numbers without decimal part where incorrectly serialised as `!!int 22.2` (for example).

The new method is still not very sophisticated, but seems to do the job :)