### PR TITLE
Fix thread safety of parser

### DIFF
--- a/src/main/scala/io/circe/yaml/parser/package.scala
+++ b/src/main/scala/io/circe/yaml/parser/package.scala
@@ -48,9 +48,10 @@ package object parser {
       getConstructor(node).construct(node)
   }
 
-  private[this] val flattener: FlatteningConstructor = new FlatteningConstructor
 
   private[this] def yamlToJson(node: Node): Either[ParsingFailure, Json] = {
+    // Isn't thread-safe internally, may hence not be shared
+    val flattener: FlatteningConstructor = new FlatteningConstructor
 
     def convertScalarNode(node: ScalarNode) = Either
       .catchNonFatal(node.getTag match {


### PR DESCRIPTION
Should resolve #112. As described in the issue, sharing the `FlatteningConstructor` isn't thread-safe as it has unsafe `HashMap` inside. It's very hard to reproduce as the problematic time window is very small (happens during hash map reorganisation), so relying on my own mental reasoning here for fixing. SnakeYAML explicitly states it isn't thread safe, see https://bitbucket.org/asomov/snakeyaml/wiki/Documentation#markdown-header-threading. 

Drawback of this PR is that it introduces a little overhead by creating a `FlatteningConstructor` for every `parse`, but I think this is justified given the safety gained.