### PR TITLE
Remove myself from maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ As part of the [circe](https://github.com/circe/circe) community, circe-yaml sup
 
 Please read the [circe Contributor's Guide](https://github.com/circe/circe/blob/master/CONTRIBUTING.md) for information about how to submit a pull request.
 
-This circe community module is currently maintained by [Jeremy Smith](https://github.com/jeremyrsmith) and [Jeff May](https://github.com/jeffmay), with guidance from [Travis Brown](https://github.com/travisbrown). It strives to conform as closely as possible to the style of circe itself.
+This circe community module is currently maintained by [Jeff May](https://github.com/jeffmay) and [Travis Brown](https://github.com/travisbrown). It strives to conform as closely as possible to the style of circe itself.


### PR DESCRIPTION
Honestly, I haven't been able to use any recent version of `circe-yaml` (though I am still using an old version of it) because lately Spark has the majority of my projects stuck on Scala 2.11 (2.12 in some cases, but only in cases where it also has to work on 2.11, and that's understandably no longer supported). I guess my OSS badness is showing, but it's hard to find the time to actively maintain things that I'm unable to use (regrettably this is far from the only example 😞 ).

So I think it's only fair that I remove myself from the list of maintainers – even though I started `circe-yaml`, I haven't contributed to its maintenance in years (apologies to @travisbrown for transferring this thing to the circe org and then eventually abandoning it, foisting maintenance onto you and @jeffmay) so I don't think I deserve any credit as a maintainer now.

I also edited to credit @travisbrown as a maintainer, given that (from what the GitHub history tells me) he's the primary person who's actively doing maintenance (apologies again!). I'm unsure whether @jeffmay is in the same boat as me, but surely @travisbrown seems to be doing the bulk of the legwork recently, so I'll ping @jeffmay one more time to provoke them to consider it 😄

(edit: Looks like Jeff is actively reviewing & merging PRs too, so this probably describes things accurately... apologies for projecting @jeffmay)