### PR TITLE
Allow customization of SnakeYAML loader options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 ```
 
 ### Parsing
-Parsing is accomplished through the `io.circe.yaml.parser` package; its API is similar to that of `circe-parser`:
+Parsing is accomplished through the `io.circe.yaml.parser._` package; its API is similar to that of `circe-parser`:
 
 ```scala
-import io.circe.yaml.parser
-val json: Either[ParsingFailure, Json] = parser.parse(yamlString)
+import io.circe.yaml.parser._
+val json: Either[ParsingFailure, Json] = parse(yamlString)
 ```
 
 Additionally, there is a function for parsing multiple YAML documents from a single string:
 
 ```scala
-val jsons: Stream[Either[ParsingFailure, Json]] = parser.parseDocuments(multiDocumentString)
+val jsons: Stream[Either[ParsingFailure, Json]] = parseDocuments(multiDocumentString)
 ```
 
 Both of these methods also support a "streaming" parse from a `java.io.Reader` – this is different from the behavior of 


### PR DESCRIPTION
SnakeYAML was updated some time ago to include add a protection for the [billion laughs attack](https://en.wikipedia.org/wiki/Billion_laughs_attack). This protection relies on an integer setting which defines the max number of aliased collections and can be set through a [parser constructor parameter](https://www.javadoc.io/doc/org.yaml/snakeyaml/latest/org/yaml/snakeyaml/LoaderOptions.html#setMaxAliasesForCollections(int)). Unfortunately SnakeYAML has an arbitrary low default value, and it would be good to have a way to customize such options in the underlying parser.

This PR is an attempt to allow customization of the underlying parser without breaking the existing API. Another option I had in mind was to move the config to be a second parameter to all public functions, but that seems to be a drastic change so I went the implicit way.