### PR TITLE
Use literal style when string has newline

### DIFF
--- a/src/main/scala/io/circe/yaml/Printer.scala
+++ b/src/main/scala/io/circe/yaml/Printer.scala
@@ -61,12 +61,15 @@ final case class Printer(
   }
 
   private def isBad(s: String): Boolean = s.indexOf('\u0085') >= 0 || s.indexOf('\ufeff') >= 0
+  private def hasNewline(s: String): Boolean = s.indexOf('\n') >= 0
 
   private def scalarStyle(value: String): DumperOptions.ScalarStyle =
     if (isBad(value)) DumperOptions.ScalarStyle.DOUBLE_QUOTED else DumperOptions.ScalarStyle.PLAIN
 
   private def stringScalarStyle(value: String): DumperOptions.ScalarStyle =
-    if (isBad(value)) DumperOptions.ScalarStyle.DOUBLE_QUOTED else StringStyle.toScalarStyle(stringStyle)
+    if (isBad(value)) DumperOptions.ScalarStyle.DOUBLE_QUOTED
+    else if (stringStyle == StringStyle.Plain && hasNewline(value)) DumperOptions.ScalarStyle.LITERAL
+    else StringStyle.toScalarStyle(stringStyle)
 
   private def scalarNode(tag: Tag, value: String) = new ScalarNode(tag, value, null, null, scalarStyle(value))
   private def stringNode(value: String) = new ScalarNode(Tag.STR, value, null, null, stringScalarStyle(value))

--- a/src/test/scala/io/circe/yaml/PrinterTests.scala
+++ b/src/test/scala/io/circe/yaml/PrinterTests.scala
@@ -35,10 +35,10 @@ class PrinterTests extends AnyFreeSpec with Matchers {
       val printer = Printer(preserveOrder = true)
       printer.pretty(json) shouldEqual
         """d: 4
-        |a: 1
-        |b: 2
-        |c: 3
-        |""".stripMargin
+          |a: 1
+          |b: 2
+          |c: 3
+          |""".stripMargin
     }
   }
 
@@ -86,6 +86,16 @@ class PrinterTests extends AnyFreeSpec with Matchers {
            |""".stripMargin
     }
 
+  }
+
+  "Plain with newlines" in {
+    val json = Json.obj("foo" -> Json.fromString("abc\nxyz\n"))
+    val printer = Printer.spaces2.copy(stringStyle = StringStyle.Plain)
+    printer.pretty(json) shouldEqual
+      s"""foo: |
+         |  abc
+         |  xyz
+         |""".stripMargin
   }
 
   "Drop null keys" in {


### PR DESCRIPTION
Currently, when printing using plain string style, if a string contains a newline (which cannot be printed in plain style), circe-yaml uses single-quoted style instead. This makes the produced YAML look rather odd, while literal style would feel more natural (this is what SnakeYAML does).

Here is an example to demonstrate it:
```scala
case class Document(foo: String, bar: String) {
  def toJMap: java.util.Map[String, Any] = {
    val map = new java.util.LinkedHashMap[String, Any]
    map.put("foo", foo)
    map.put("bar", bar)
    map
  }
}

val foo = Document("some text", "abc\nxyz\n")
println("== circe-yaml ==")
println(Printer(stringStyle = StringStyle.Plain).pretty(foo.asJson))
println("== SnakeYAML ==")
println(new Yaml().dump(foo.toJMap))
```
Output:
```
== circe-yaml ==
foo: some text
bar: 'abc

  xyz

  '

== SnakeYAML ==
foo: some text
bar: |
  abc
  xyz

```
With this PR, circe-yaml would produce the same output as SnakeYAML in the example above.