### PR TITLE
Extend from Parser

### DIFF
--- a/src/main/scala/io/circe/yaml/parser/package.scala
+++ b/src/main/scala/io/circe/yaml/parser/package.scala
@@ -8,7 +8,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes._
 import scala.collection.JavaConverters._
 
-package object parser {
+package object parser extends Parser {
 
   /**
    * Parse YAML from the given [[Reader]], returning either [[ParsingFailure]] or [[Json]]


### PR DESCRIPTION
Extending from Parser adds some convenience methods to the Parser out of the box, such as `decodeAccumulating`.
The parser package object already matches the Parser interface.

Relates to #199 