### PR TITLE
Extend from Yaml Parser from Core Parser

### DIFF
--- a/src/main/scala/io/circe/yaml/Parser.scala
+++ b/src/main/scala/io/circe/yaml/Parser.scala
@@ -1,6 +1,7 @@
 package io.circe.yaml
 
 import Parser._
+import cats.data.ValidatedNel
 import cats.syntax.either._
 import io.circe._
 import java.io.{ Reader, StringReader }
@@ -12,7 +13,7 @@ import scala.collection.JavaConverters._
 
 final case class Parser(
   maxAliasesForCollections: Int = 50
-) {
+) extends io.circe.Parser {
 
   private val loaderOptions = {
     val options = new LoaderOptions()
@@ -40,6 +41,12 @@ final case class Parser(
 
   private[this] def parseStream(reader: Reader): Stream[Node] =
     new Yaml(loaderOptions).composeAll(reader).asScala.toStream
+
+  final def decode[A: Decoder](input: Reader): Either[Error, A] =
+    finishDecode(parse(input))
+
+  final def decodeAccumulating[A: Decoder](input: Reader): ValidatedNel[Error, A] =
+    finishDecodeAccumulating(parse(input))
 }
 
 object Parser {

--- a/src/main/scala/io/circe/yaml/parser/package.scala
+++ b/src/main/scala/io/circe/yaml/parser/package.scala
@@ -8,7 +8,7 @@ import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.nodes._
 import scala.collection.JavaConverters._
 
-package object parser {
+package object parser extends Parser {
 
   /**
    * Parse YAML from the given [[Reader]], returning either [[ParsingFailure]] or [[Json]]

--- a/src/main/scala/io/circe/yaml/parser/package.scala
+++ b/src/main/scala/io/circe/yaml/parser/package.scala
@@ -1,5 +1,6 @@
 package io.circe.yaml
 
+import cats.data.ValidatedNel
 import cats.syntax.either._
 import io.circe._
 import java.io._
@@ -8,7 +9,7 @@ import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.nodes._
 import scala.collection.JavaConverters._
 
-package object parser extends Parser {
+package object parser {
 
   /**
    * Parse YAML from the given [[Reader]], returning either [[ParsingFailure]] or [[Json]]
@@ -21,6 +22,14 @@ package object parser extends Parser {
 
   def parseDocuments(yaml: Reader): Stream[Either[ParsingFailure, Json]] = Parser.default.parseDocuments(yaml)
   def parseDocuments(yaml: String): Stream[Either[ParsingFailure, Json]] = Parser.default.parseDocuments(yaml)
+
+  final def decode[A: Decoder](input: String): Either[Error, A] = Parser.default.decode[A](input)
+  final def decode[A: Decoder](input: Reader): Either[Error, A] = Parser.default.decode[A](input)
+
+  final def decodeAccumulating[A: Decoder](input: String): ValidatedNel[Error, A] =
+    Parser.default.decodeAccumulating[A](input)
+  final def decodeAccumulating[A: Decoder](input: Reader): ValidatedNel[Error, A] =
+    Parser.default.decodeAccumulating[A](input)
 
   @deprecated("moved to Parser.CustomTag", since = "0.14.2")
   private val loaderOptions = {


### PR DESCRIPTION
Extending from `io.circe.Parser` adds some convenience methods to the `io.circe.yaml.Parser` out of the box, such as `decodeAccumulating`.

The `io.circe.yaml.Parser` class already matches the `io.circe.Parser` interface.

Also added `decode` and friends to the `io.circe.yaml.parser` package manually as well (using the `io.circe.Parser` trait had some compilation issues)

supersedes https://github.com/circe/circe-yaml/pull/284