### PR TITLE
🧹 Cleanup CI / CD / build issues and prepare for release of v0.15.1 🚀 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ on:
     tags: [v*]
 
 env:
-  PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-  SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-  SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
-  SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  PGP_SECRET: ${{ secrets.PGP_SECRET }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,64 +29,47 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.18, 2.13.12, 3.3.1]
+        scala: [2.12, 2.13, 3]
         java: [temurin@11, temurin@17]
         project: [rootJVM]
         exclude:
-          - scala: 2.12.18
+          - scala: 2.12
             java: temurin@17
-          - scala: 3.3.1
+          - scala: 3
             java: temurin@17
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 11
-
       - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
-
-      - name: Download Java (temurin@17)
-        id: download-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v2
-        with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 17
-          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      - name: sbt update
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
@@ -95,12 +78,12 @@ jobs:
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
-      - name: Test
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
-
       - name: Check scalafix lints
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' 'scalafixAll --check'
+
+      - name: Test
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
@@ -112,11 +95,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p circe-yaml-v12/target target circe-yaml-common/target .js/target circe-yaml/target .jvm/target .native/target project/target
+        run: mkdir -p circe-yaml-v12/target circe-yaml-common/target circe-yaml/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar circe-yaml-v12/target target circe-yaml-common/target .js/target circe-yaml/target .jvm/target .native/target project/target
+        run: tar cf targets.tar circe-yaml-v12/target circe-yaml-common/target circe-yaml/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -136,94 +119,132 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 11
-
       - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
-
-      - name: Download Java (temurin@17)
-        id: download-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v2
-        with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 17
-          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      - name: sbt update
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
 
-      - name: Download target directories (2.12.18, rootJVM)
+      - name: Download target directories (2.12, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.18-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-rootJVM
 
-      - name: Inflate target directories (2.12.18, rootJVM)
+      - name: Inflate target directories (2.12, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.12, rootJVM)
+      - name: Download target directories (2.13, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.12-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-rootJVM
 
-      - name: Inflate target directories (2.13.12, rootJVM)
+      - name: Inflate target directories (2.13, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.3.1, rootJVM)
+      - name: Download target directories (3, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.1-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJVM
 
-      - name: Inflate target directories (3.3.1, rootJVM)
+      - name: Inflate target directories (3, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: echo $PGP_SECRET | base64 -di | gpg --import
 
       - name: Import signing key and strip passphrase
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
           echo "$PGP_SECRET" | base64 -di > /tmp/signing-key.gpg
           echo "$PGP_PASSPHRASE" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
         run: sbt tlCiRelease
+
+  dependency-submission:
+    name: Submit Dependencies
+    if: github.event_name != 'pull_request'
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Submit Dependencies
+        uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          modules-ignore: rootjs_2.12 rootjs_2.13 rootjs_3 rootjvm_2.12 rootjvm_2.13 rootjvm_3 rootnative_2.12 rootnative_2.13 rootnative_3
+          configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / tlBaseVersion := "1.15"
 ThisBuild / circeRootOfCodeCoverage := None
 ThisBuild / startYear := Some(2016)
 ThisBuild / scalafixScalaBinaryVersion := "2.12"
-ThisBuild / tlFatalWarningsInCi := false //TODO: ... fix this someday
+ThisBuild / tlFatalWarnings := false //TODO: ... fix this someday
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
 
 val Versions = new {

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "1.15"
+ThisBuild / tlBaseVersion := "0.15"
 ThisBuild / circeRootOfCodeCoverage := None
 ThisBuild / startYear := Some(2016)
 ThisBuild / scalafixScalaBinaryVersion := "2.12"
@@ -13,7 +13,7 @@ val Versions = new {
   val scalaTestPlus = "3.2.14.0"
   val snakeYaml = "2.2"
   val snakeYamlEngine = "2.7"
-  val previousCirceYamls = Set("0.14.0", "0.14.1", "0.14.2", "0.15.0")
+  val previousCirceYamls = Set("0.14.0", "0.14.1", "0.14.2")
 
   val scala212 = "2.12.18"
   val scala213 = "2.13.12"
@@ -37,7 +37,8 @@ lazy val `circe-yaml-common` = project
     description := "Library for converting between SnakeYAML's AST (YAML 1.1) and circe's AST",
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % Versions.circe
-    )
+    ),
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.14.3").toMap
   )
 
 lazy val `circe-yaml` = project
@@ -52,7 +53,7 @@ lazy val `circe-yaml` = project
       "org.typelevel" %% "discipline-core" % Versions.discipline % Test,
       "org.scalacheck" %% "scalacheck" % Versions.scalaCheck % Test,
       "org.scalatest" %% "scalatest" % Versions.scalaTest % Test,
-      "org.scalatestplus" %% "scalacheck-1-16" % Versions.scalaTestPlus % Test
+      "org.scalatestplus" %% "scalacheck-1-17" % Versions.scalaTestPlus % Test
     )
   )
 
@@ -68,8 +69,9 @@ lazy val `circe-yaml-v12` = project
       "org.typelevel" %% "discipline-core" % Versions.discipline % Test,
       "org.scalacheck" %% "scalacheck" % Versions.scalaCheck % Test,
       "org.scalatest" %% "scalatest" % Versions.scalaTest % Test,
-      "org.scalatestplus" %% "scalacheck-1-16" % Versions.scalaTestPlus % Test
-    )
+      "org.scalatestplus" %% "scalacheck-1-17" % Versions.scalaTestPlus % Test
+    ),
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.14.3").toMap
   )
 
 ThisBuild / developers := List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.circe" % "sbt-circe-org" % "0.1.4")
+addSbtPlugin("io.circe" % "sbt-circe-org" % "0.2.1")


### PR DESCRIPTION
## About this PR

Included the upgrade to sbt-circe-org out of concern for an out-dated release process, however, the issue was a simple fix of changing `tlBaseVersion` from `1.15` to `0.15` (which was my bad 🤦 )

**A 1.15.0 artifact was released** which I cannot undo. Instead I am going to mark note it in the releases and suggest people upgrade to 0.15.1 which will contain all of these changes.

I'm not really sure how to deal with all of the damage downstream from Scala Steward upgrades... Is there a way to mark a release as broken?

📦 Updates [io.circe:sbt-circe-org](https://github.com/circe/sbt-circe-org) from `0.1.4` to `0.2.1`

📜 [GitHub Release Notes](https://github.com/circe/sbt-circe-org/releases/tag/v0.2.1) - [Version Diff](https://github.com/circe/sbt-circe-org/compare/v0.1.4...v0.2.1)

<sup>
labels: sbt-plugin-update, early-semver-major, semver-spec-minor, version-scheme:early-semver, commit-count:n:2
</sup>