### PR TITLE
Added indentWithIndicator option

### DIFF
--- a/circe-yaml-v12/src/main/scala/io/circe/yaml/v12/Printer.scala
+++ b/circe-yaml-v12/src/main/scala/io/circe/yaml/v12/Printer.scala
@@ -36,7 +36,8 @@ object Printer {
     stringStyle: StringStyle = StringStyle.Plain,
     lineBreak: LineBreak = LineBreak.Unix,
     explicitStart: Boolean = false,
-    explicitEnd: Boolean = false
+    explicitEnd: Boolean = false,
+    indentWithIndicator: Boolean = false,
   )
 
   def make(config: Config = Config()): common.Printer = {
@@ -64,6 +65,7 @@ object Printer {
             case LineBreak.Mac     => "\r"
           }
         }
+        .setIndentWithIndicator(indentWithIndicator)
         .build()
     )
   }

--- a/circe-yaml-v12/src/test/scala/io/circe/yaml/v12/PrinterTests.scala
+++ b/circe-yaml-v12/src/test/scala/io/circe/yaml/v12/PrinterTests.scala
@@ -155,4 +155,18 @@ class PrinterTests extends AnyFreeSpec with Matchers {
     }
   }
 
+  "Indent indicators" - {
+    val json = Json.obj("arr" -> Json.arr(Json.fromString("foo"), Json.fromString("bar")))
+
+    "defaults" in {
+      Printer.make(Printer.Config(indentWithIndicator = false, indicatorIndent = 0)).pretty(json) shouldEqual
+        "arr:\n- foo\n- bar\n"
+    }
+
+    "Indent arrays" in {
+      Printer.make(Printer.Config(indentWithIndicator = true, indicatorIndent = 2)).pretty(json) shouldEqual
+        "arr:\n  - foo\n  - bar\n"
+    }
+  }
+
 }


### PR DESCRIPTION
I needed to indent yaml like:

```
array:
  - item 1
  - item 2
```

This PR adds snakeYamls `indentWithIndicator` to io.circe.yaml.v12.Printer.Config that together with `indicatorIndent` allows printing format above.